### PR TITLE
set default entity tile from TileRect

### DIFF
--- a/addons/ldtk-importer/src/util/definition_util.gd
+++ b/addons/ldtk-importer/src/util/definition_util.gd
@@ -35,6 +35,9 @@ static func resolve_entity_definitions(entity_defs: Array) -> Dictionary:
 	var resolved_entity_defs := {}
 
 	for entity_def in entity_defs:
+		var entity_tile = entity_def.uiTileRect
+		if entity_tile == null:
+			entity_tile = entity_def.tileRect
 		resolved_entity_defs[entity_def.uid] = {
 			"identifier": entity_def.identifier,
 			"color": Color.from_string(entity_def.color, Color.MAGENTA),
@@ -42,7 +45,7 @@ static func resolve_entity_definitions(entity_defs: Array) -> Dictionary:
 			"hollow": entity_def.hollow,
 			"tags": entity_def.tags,
 			"field_defs": resolve_entity_field_defs(entity_def.fieldDefs),
-			"tile": entity_def.uiTileRect
+			"tile": entity_tile
 		}
 
 	return resolved_entity_defs


### PR DESCRIPTION
If `entity_definition.uiTileRect` is null, this will set the default tile `entity_definition.TileRect`

Closes #35